### PR TITLE
Update Caddyfile

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -4,7 +4,7 @@
 }
 
 :9443 {
-    tls self_signed
+    tls internal
     templates
     browse
 }


### PR DESCRIPTION
with a current release of caddy using self-signed provides the following error
2020/04/17 16:48:29 self-signed: certificate has no names

Suggest changing tls to internal (built-in cert).